### PR TITLE
Do not release react events to the pool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ Refer to the TODO app in react-hs-examples for some of the details.
 - `mkStore` is gone, you need to call `registerInitialStore` in the beginning of your main function.
 - calls to `mkControllerView` contain a type argument that is a list of all stores that you want to pass to the function that constructs the content.
 - make Eq instances for all your prop, state, store types ([check out the example](https://github.com/liqula/react-hs/blob/a5d2d88f6da91a2243ee5cc9ca608e1580a4139d/react-hs-examples/src/TodoComponents.hs#L28) if you have un-Eq-able types like functions.)
-- add lines `instance UnoverlapAllEq X` for all types `X` that give you type errors.  [you can't do anything wrong here as long as you do not instantiate 'StoreArg' or 'StoreField'.  this is just a hack to sort out overlapping instances.](https://github.com/liqula/react-hs/blob/41f325790b9a8f4ca75d88a5d8c18dc145f3c1e3/react-hs/src/React/Flux/Internal.hs#L593)
-- `stopPropagation`, `preventDefault` are used differently now.  you should run them first thing in the event handler, like this: `div_ [onClick $ \evt _ -> stopPropagation evt `seq` dispatch MyAction] $ ...`.
+- `stopPropagation`, `preventDefault` are used differently now.  They are modifiers of the event handler types, so you should call them like this: `div_ [onClick $ \_evt _mevt -> stopPropagation $ dispatch MyAction] $ ...`.  Also, you now need to call an empty modification function 'simpleHandler' if you don't want to do any of this.  The type errors will guide you.  Check out the TODO example and the haddocks of 'simpleHandler'.
 
 I think that's the gist of it, but I'm pretty sure i forgot a few
 interesting details.  If you need more details or run into any
@@ -88,5 +87,3 @@ questions, please open an issue.
 - https://www.stackage.org/package/glazier-react-examples (i have not looked at this yet.)
 - http://blog.wuzzeb.org/
 - http://iankduncan.com/posts/2014-12-16-react-js-with-ghcjs.html
-
-

--- a/react-hs-examples/react-hs-examples.cabal
+++ b/react-hs-examples/react-hs-examples.cabal
@@ -23,36 +23,93 @@ source-repository head
     location: https://github.com/liqula/react-hs
 
 executable todo
-   ghc-options: -Wall
-   cpp-options: -DGHCJS_BROWSER
+  ghc-options: -Wall -fno-warn-redundant-constraints
+  cpp-options: -DGHCJS_BROWSER
 
-   other-modules: TodoComponents
-                , TodoDispatcher
-                , TodoStore
-                , TodoViews
+  other-modules: TodoComponents
+               , TodoDispatcher
+               , TodoStore
+               , TodoViews
 
-   default-language: Haskell2010
-   hs-source-dirs: src
-   main-is: Main.hs
-   build-depends: base
-                , react-hs >= 0.0 && < 0.1
-                , deepseq
-                , text
-                , ghcjs-base
+  default-language: Haskell2010
+  hs-source-dirs: src
+  main-is: Main.hs
+  build-depends: base
+               , react-hs >= 0.0 && < 0.1
+               , text
+               , ghcjs-base
+
+  default-extensions:
+    AllowAmbiguousTypes
+    BangPatterns
+    CPP
+    DataKinds
+    DeriveGeneric
+    EmptyDataDecls
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    MagicHash
+    MultiParamTypeClasses
+    OverloadedStrings
+    PolyKinds
+    QuasiQuotes
+    RecordWildCards
+    ScopedTypeVariables
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
+
 
 executable todo-node
-   ghc-options: -Wall
+  ghc-options: -Wall -fno-warn-redundant-constraints
 
-   other-modules: TodoComponents
-                , TodoDispatcher
-                , TodoStore
-                , TodoViews
+  other-modules: TodoComponents
+               , TodoDispatcher
+               , TodoStore
+               , TodoViews
 
-   default-language: Haskell2010
-   hs-source-dirs: src
-   main-is: NodeMain.hs
-   build-depends: base
-                , react-hs >= 0.0 && < 0.1
-                , deepseq
-                , text
-                , ghcjs-base
+  default-language: Haskell2010
+  hs-source-dirs: src
+  main-is: NodeMain.hs
+  build-depends: base
+               , react-hs >= 0.0 && < 0.1
+               , text
+               , ghcjs-base
+
+  default-extensions:
+    AllowAmbiguousTypes
+    BangPatterns
+    CPP
+    DataKinds
+    DeriveGeneric
+    EmptyDataDecls
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    MagicHash
+    MultiParamTypeClasses
+    OverloadedStrings
+    PolyKinds
+    QuasiQuotes
+    RecordWildCards
+    ScopedTypeVariables
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns

--- a/react-hs-examples/react-hs-examples.cabal
+++ b/react-hs-examples/react-hs-examples.cabal
@@ -1,5 +1,5 @@
 name:                react-hs-examples
-version:             0.0.1
+version:             0.1.0
 synopsis:            An example react-hs application
 category:            Web
 homepage:            https://github.com/liqula/react-hs
@@ -35,7 +35,7 @@ executable todo
   hs-source-dirs: src
   main-is: Main.hs
   build-depends: base
-               , react-hs >= 0.0 && < 0.1
+               , react-hs >= 0.1 && < 0.2
                , text
                , ghcjs-base
 
@@ -81,7 +81,7 @@ executable todo-node
   hs-source-dirs: src
   main-is: NodeMain.hs
   build-depends: base
-               , react-hs >= 0.0 && < 0.1
+               , react-hs >= 0.1 && < 0.2
                , text
                , ghcjs-base
 

--- a/react-hs-examples/spec/TodoSpec.hs
+++ b/react-hs-examples/spec/TodoSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module TodoSpec (spec) where
 
 import           Control.Monad

--- a/react-hs-examples/spec/todo-spec.cabal
+++ b/react-hs-examples/spec/todo-spec.cabal
@@ -1,5 +1,5 @@
 name: todo-spec
-version: 0.0.1
+version: 0.1.0
 build-type: Simple
 cabal-version: >= 1.9
 

--- a/react-hs-examples/spec/todo-spec.cabal
+++ b/react-hs-examples/spec/todo-spec.cabal
@@ -4,16 +4,45 @@ build-type: Simple
 cabal-version: >= 1.9
 
 executable todo-spec
-   ghc-options: -Wall
-   hs-source-dirs: .
-   main-is: Main.hs
-   other-modules: TodoSpec, Spec
-   build-depends: base
-                , hspec
-                , webdriver
-                , hspec-webdriver >= 1.2
-                , directory
-                , process
-                , transformers
-                , text
-                , time
+  ghc-options: -Wall
+  hs-source-dirs: .
+  main-is: Main.hs
+  other-modules: TodoSpec, Spec
+  build-depends: base
+               , hspec
+               , webdriver
+               , hspec-webdriver >= 1.2
+               , directory
+               , process
+               , transformers
+               , text
+               , time
+
+  default-extensions:
+    AllowAmbiguousTypes
+    BangPatterns
+    CPP
+    DataKinds
+    DeriveGeneric
+    EmptyDataDecls
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    MagicHash
+    MultiParamTypeClasses
+    OverloadedStrings
+    PolyKinds
+    QuasiQuotes
+    RecordWildCards
+    ScopedTypeVariables
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns

--- a/react-hs-examples/src/Main.hs
+++ b/react-hs-examples/src/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
 import React.Flux

--- a/react-hs-examples/src/TodoDispatcher.hs
+++ b/react-hs-examples/src/TodoDispatcher.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE TypeApplications #-}
-module TodoDispatcher (dispatchTodo) where
+module TodoDispatcher (dispatchTodo, handleTodo) where
 
 import React.Flux
 import TodoStore
 
 dispatchTodo :: TodoAction -> [SomeStoreAction]
 dispatchTodo a = [action @TodoState a]
+
+handleTodo :: TodoAction -> ([SomeStoreAction], [EventModification])
+handleTodo = simpleHandler . dispatchTodo

--- a/react-hs-examples/src/TodoStore.hs
+++ b/react-hs-examples/src/TodoStore.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE TypeFamilies, DeriveGeneric, DeriveAnyClass, OverloadedStrings #-}
 module TodoStore where
 
 import React.Flux
-import Control.DeepSeq
 import GHC.Generics (Generic)
 import Data.Typeable (Typeable)
 import qualified Data.Text as T
@@ -24,7 +22,7 @@ data TodoAction = TodoCreate T.Text
                 | ToggleAllComplete
                 | TodoSetComplete Int Bool
                 | ClearCompletedTodos
-  deriving (Show, Typeable, Generic, NFData)
+  deriving (Show, Typeable, Generic)
 
 instance StoreData TodoState where
     type StoreAction TodoState = TodoAction

--- a/react-hs-servant/react-hs-servant.cabal
+++ b/react-hs-servant/react-hs-servant.cabal
@@ -1,5 +1,5 @@
 name:                react-hs-servant
-version:             0.0.1
+version:             0.1.0
 synopsis:            Allow react-hs stores to send requests to a servant server
 category:            Web
 homepage:            https://github.com/liqula/react-hs
@@ -53,7 +53,7 @@ library
     ViewPatterns
 
   build-depends: base >= 4.8 && < 5
-               , react-hs >= 0.0 && < 0.1
+               , react-hs >= 0.1 && < 0.2
                , servant >= 0.7
                , aeson >= 0.8
                , text >= 1.2

--- a/react-hs-servant/react-hs-servant.cabal
+++ b/react-hs-servant/react-hs-servant.cabal
@@ -25,14 +25,32 @@ library
   default-language: Haskell2010
   exposed-modules: React.Flux.Addons.Servant
 
-  default-extensions: TypeOperators
-                      DataKinds
-                      PolyKinds
-                      TypeFamilies
-                      FlexibleInstances
-                      FlexibleContexts
-                      OverloadedStrings
-                      ScopedTypeVariables
+  default-extensions:
+    BangPatterns
+    CPP
+    DataKinds
+    DeriveGeneric
+    EmptyDataDecls
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    MagicHash
+    MultiParamTypeClasses
+    OverloadedStrings
+    PolyKinds
+    QuasiQuotes
+    RecordWildCards
+    ScopedTypeVariables
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
 
   build-depends: base >= 4.8 && < 5
                , react-hs >= 0.0 && < 0.1

--- a/react-hs-servant/src/React/Flux/Addons/Servant.hs
+++ b/react-hs-servant/src/React/Flux/Addons/Servant.hs
@@ -32,7 +32,7 @@
 --                      | RequestUserResponse UserId (Either (Int,String) User)
 --                      | UpdateUser UserId User
 --                      | UpdateUserResponse UserId (Either (Int, String) ())
---   deriving (Show, Generic, NFData)
+--   deriving (Show, Generic)
 --
 -- cfg :: ApiRequestConfig MyAPI
 -- cfg = ApiRequestConfig "https://www.example.com" NoTimeout
@@ -71,7 +71,6 @@
 -- userStore :: ReactStore UserStore
 -- userStore = mkStore $ UserStore Map.empty NoPendingRequest
 -- @
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 module React.Flux.Addons.Servant(
     HandleResponse
   , RequestTimeout(..)

--- a/react-hs/react-hs.cabal
+++ b/react-hs/react-hs.cabal
@@ -24,7 +24,7 @@ source-repository head
 
 library
   hs-source-dirs:      src
-  ghc-options: -Wall
+  ghc-options: -Wall -fno-warn-redundant-constraints
   default-language: Haskell2010
   js-sources: jsbits/views.js
               jsbits/store.js
@@ -45,23 +45,36 @@ library
                    React.Flux.Store
                    React.Flux.Views
 
-  default-extensions: EmptyDataDecls
-                      ExistentialQuantification
-                      FlexibleContexts
-                      FlexibleInstances
-                      FunctionalDependencies
-                      GeneralizedNewtypeDeriving
-                      MultiParamTypeClasses
-                      DeriveGeneric
-                      OverloadedStrings
-                      ScopedTypeVariables
-                      TypeFamilies
-                      PolyKinds
-                      DataKinds
-                      TypeOperators
+  default-extensions:
+    AllowAmbiguousTypes
+    BangPatterns
+    CPP
+    DataKinds
+    DeriveGeneric
+    EmptyDataDecls
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    MagicHash
+    MultiParamTypeClasses
+    OverloadedStrings
+    PolyKinds
+    QuasiQuotes
+    RecordWildCards
+    ScopedTypeVariables
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeFamilyDependencies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns
 
   build-depends: base >=4.9 && < 5
-               , deepseq
                , mtl >= 2.1
                , aeson >= 0.8
                , text >= 1.2

--- a/react-hs/react-hs.cabal
+++ b/react-hs/react-hs.cabal
@@ -1,5 +1,5 @@
 name:                react-hs
-version:             0.0.1
+version:             0.1.0
 synopsis:            A binding to React based on the Flux application architecture for GHCJS
 category:            Web
 homepage:            https://github.com/liqula/react-hs

--- a/react-hs/src/React/Flux.hs
+++ b/react-hs/src/React/Flux.hs
@@ -58,7 +58,6 @@
 -- The file <https://bitbucket.org/wuzzeb/react-flux/src/tip/test/spec/TodoSpec.hs test\/spec\/TodoSpec.hs>
 -- in the source code contains a hspec-webdriver test for the TODO example application.
 
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports #-} -- ArgumentsToProps is exported twice, once by React.Flux.PropertiesAndEvents and once here
 
 module React.Flux (
@@ -75,6 +74,7 @@ module React.Flux (
   , readStoreData
 
   -- * Views
+  , EventHandlerType, EventHandlerCode(..)
   , ViewEventHandler
   , View
   , ViewPropsToElement
@@ -92,7 +92,8 @@ module React.Flux (
 
   -- * Elements
   , ReactElement
-  , ReactElementM(..)
+  , ReactElementM_(..)
+  , ReactElementM
   , elemString
   , elemText
   , elemJSString
@@ -133,6 +134,10 @@ reactRenderView :: JSString -- ^ The ID of the HTML element to render the applic
                       -- (This string is passed to @document.getElementById@)
                 -> View '[] -- ^ A single instance of this view is created
                 -> IO ()
+reactRenderView htmlId (View rc) = do
+  let element = elementToM () $ NewViewElement rc htmlId (const $ return ())
+  (e, _) <- mkReactElement @'EventHandlerCode (const $ pure ()) (ReactThis nullRef) element
+  js_ReactRender e htmlId
 
 -- | Render your React application to a string using either @ReactDOMServer.renderToString@ if the first
 -- argument is false or @ReactDOMServer.renderToStaticMarkup@ if the first argument is true.
@@ -147,13 +152,9 @@ reactRenderViewToString :: Bool -- ^ Render to static markup?  If true, this won
                                 -- that React uses internally.
                         -> View '[] -- ^ A single instance of this view is created
                         -> IO Text
-
-reactRenderView htmlId (View rc) = do
-  (e, _) <- mkReactElement id (ReactThis nullRef) $ elementToM () $ NewViewElement rc htmlId (const $ return ())
-  js_ReactRender e htmlId
-
 reactRenderViewToString includeStatic (View rc) = do
-  (e, _) <- mkReactElement id (ReactThis nullRef) $ elementToM () $ NewViewElement rc "main" (const $ return ())
+  let element = elementToM () $ NewViewElement rc "main" (const $ return ())
+  (e, _) <- mkReactElement @'EventHandlerCode (const $ pure ()) (ReactThis nullRef) element
   sRef <- (if includeStatic then js_ReactRenderStaticMarkup else js_ReactRenderToString) e
   mtxt <- fromJSVal sRef
   maybe (error "Unable to convert string return to Text") return mtxt

--- a/react-hs/src/React/Flux/Addons/Bootstrap.hs
+++ b/react-hs/src/React/Flux/Addons/Bootstrap.hs
@@ -8,8 +8,6 @@
 -- library.  I am currently using <http://www.material-ui.com Material UI> and accessing the
 -- components using @foreign_@.
 
-{-# LANGUAGE CPP #-}
-
 module React.Flux.Addons.Bootstrap (
     bootstrap_
 ) where
@@ -33,14 +31,13 @@ import React.Flux.Internal (toJSString)
 -- >    bootstrap_ "NavItem" ["eventKey" @= (2 :: Int)] "Item 2"
 -- >    bootstrap_ "NavItem" ["eventKey" @= (3 :: Int)] "Item 3"
 bootstrap_ :: String
-           -- ^ The component name.   Uses @window[\'ReactBootstrap\'][name]@ to find the class, so
-           -- the name can be anything exported to the @window.ReactBoostrap@ object.
+               -- ^ The component name.   Uses @window[\'ReactBootstrap\'][name]@ to find the class, so
+               -- the name can be anything exported to the @window.ReactBoostrap@ object.
            -> [PropertyOrHandler eventHandler]
-           -- ^ Properties and callbacks to pass to the ReactBootstrap class.  You can use 'callback'
-           -- to create function properties.
+               -- ^ Properties and callbacks to pass to the ReactBootstrap class.  You can use 'callback'
+               -- to create function properties.
            -> ReactElementM eventHandler a -- ^ The child or children of the component.
            -> ReactElementM eventHandler a
-
 bootstrap_ n = foreignClass (js_ReactBootstrap $ toJSString n)
 
 #ifdef __GHCJS__

--- a/react-hs/src/React/Flux/Addons/Intl.hs
+++ b/react-hs/src/React/Flux/Addons/Intl.hs
@@ -80,8 +80,6 @@
 --        locale into a store and use a controller-view to pass the locale and lookup the messages
 --        for 'intlProvider_'.
 
-{-# LANGUAGE CPP, TemplateHaskell, QuasiQuotes, OverloadedStrings #-}
-
 module React.Flux.Addons.Intl(
     intlProvider_
 
@@ -148,7 +146,7 @@ import Data.Time
 import Language.Haskell.TH (runIO, Q, Loc, location, ExpQ)
 import Language.Haskell.TH.Syntax (liftString, qGetQ, qPutQ, reportWarning, Dec)
 import React.Flux
-import React.Flux.Internal (PropertyOrHandler(PropertyFromContext), toJSString)
+import React.Flux.Internal (PropertyOrHandler_(PropertyFromContext), toJSString)
 import System.IO (withFile, IOMode(..))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as B
@@ -377,12 +375,11 @@ formattedDate_ t props = foreignClass js_formatDate (valProp:props) mempty
 formattedDateProp :: JSString -- ^ the property to set
                   -> Either Day UTCTime -- ^ the day or time to format
                   -> [IntlProperty] -- ^ Any options supported by
-                                    -- <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat Intl.DateTimeFormat>.
+                                    -- <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat
+                                    -- Intl.DateTimeFormat>.
                   -> PropertyOrHandler eventHandler
-formattedDateProp name (Left day) options =
-    formatCtx name "formatDate" (dayToJSVal day) options
-formattedDateProp name (Right time) options =
-    formatCtx name "formatTime" (timeToJSVal time) options
+formattedDateProp name (Left day)   = formatCtx name "formatDate" (dayToJSVal day)
+formattedDateProp name (Right time) = formatCtx name "formatTime" (timeToJSVal time)
 
 -- | Display the 'UTCTime' as a relative time.  In addition, wrap the display in a HTML5
 -- <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time time> element.
@@ -423,7 +420,7 @@ plural_ props = foreignClass js_formatPlural props mempty
 -- | Format a number properly based on pluralization, and then use it as the value for a property.
 -- 'plural_' should be preferred, but 'pluralProp' can be used in places where a component is not
 -- possible such as the placeholder of an input element.
-pluralProp :: ToJSVal val => JSString -> val -> [IntlProperty] -> PropertyOrHandler eventHandler
+pluralProp :: (ToJSVal val) => JSString -> val -> [IntlProperty] -> PropertyOrHandler eventHandler
 pluralProp name val options = formatCtx name "formatPlural" val options
 
 --------------------------------------------------------------------------------

--- a/react-hs/src/React/Flux/Addons/React.hs
+++ b/react-hs/src/React/Flux/Addons/React.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP, TypeApplications #-}
-
 -- | Bindings for the <https://facebook.github.io/react/docs/addons.html React addons> that make
 -- sense to use from Haskell.  At the moment, that is only the
 -- <https://facebook.github.io/react/docs/animation.html animation> and
@@ -15,7 +13,6 @@ module React.Flux.Addons.React (
   , perfA
 ) where
 
-import Control.DeepSeq (NFData)
 import Control.Monad (forM_)
 import GHC.Generics (Generic)
 import React.Flux
@@ -45,17 +42,11 @@ data PerfPrint = PerfPrintInclusive
                | PerfPrintDOM
     deriving (Show, Eq, Generic)
 
-instance UnoverlapAllEq [PerfPrint]
-
-instance NFData PerfPrint
-
 -- | An action to start or stop performance measurement.  For details, see
 -- <https://facebook.github.io/react/docs/perf.html>.
 data PerfAction = PerfStart
                 | PerfStopAndPrint [PerfPrint]
     deriving (Show, Eq, Generic)
-
-instance NFData PerfAction
 
 instance StoreData PerfStoreData where
     type StoreAction PerfStoreData = PerfAction
@@ -85,7 +76,7 @@ perfA a = action @PerfStoreData a
 -- | The performance toggle button view
 perfToggleButton :: View '[[PerfPrint]]
 perfToggleButton = mkControllerView @'[StoreArg PerfStoreData] "perf toggle button" $ \sData toPrint ->
-    button_ [ onClick $ \_ _ ->
+    button_ [ onClick $ \_ _ -> simpleHandler $
                 if perfIsActive sData
                     then [perfA $ PerfStopAndPrint toPrint]
                     else [perfA PerfStart]
@@ -96,7 +87,7 @@ perfToggleButton = mkControllerView @'[StoreArg PerfStoreData] "perf toggle butt
 -- measurement is stopped, the given measurements are printed.  If you want more control over the
 -- performance tools, you can use 'perfA' directly from your own event handlers.
 perfToggleButton_ :: [PerfPrint] -> ReactElementM handler ()
-perfToggleButton_ toPrint = view_ perfToggleButton "perf-toggle-button" toPrint
+perfToggleButton_ = view_ perfToggleButton "perf-toggle-button"
 
 #ifdef __GHCJS__
 

--- a/react-hs/src/React/Flux/Ajax.hs
+++ b/react-hs/src/React/Flux/Ajax.hs
@@ -2,9 +2,6 @@
 -- in that it mostly directly exposes the XMLHttpRequest access.  If you are using
 -- servant, <http://hackage.haskell.org/package/react-flux-servant react-flux-servant>
 -- for a higher-level interface.
-
-{-# LANGUAGE CPP #-}
-
 module React.Flux.Ajax (
     initAjax
   , RequestTimeout(..)
@@ -23,7 +20,6 @@ import React.Flux.Internal
 import React.Flux.Store
 
 import Control.Arrow ((***))
-import Control.DeepSeq (deepseq)
 import GHCJS.Foreign.Callback
 import GHCJS.Foreign (jsNull)
 import GHCJS.Foreign.Export
@@ -66,9 +62,7 @@ data HandlerWrapper = HandlerWrapper (AjaxResponse -> IO [SomeStoreAction])
 -- | This is broken out as a separate function because if the code is inlined (either manually or by
 -- ghc), there is a runtime error.
 useHandler :: AjaxResponse -> HandlerWrapper -> IO ()
-useHandler r (HandlerWrapper h) = do
-    actions <- h r
-    actions `deepseq` mapM_ executeAction actions
+useHandler r (HandlerWrapper h) = mapM_ executeAction =<< h r
 {-# NOINLINE useHandler #-} -- if this is inlined, there is a bug in ghcjs
 
 -- | If you are going to use 'ajax' or 'jsonAjax', you must call 'initAjax' once from your main
@@ -114,7 +108,7 @@ ajax req handler = do
 -- >data MyStoreAction = LaunchTheMissiles Target
 -- >                   | MissilesLaunched Trajectory
 -- >                   | UnableToLaunchMissiles Text
--- >  deriving (Typeable, Generic, NFData)
+-- >  deriving (Typeable, Generic)
 -- >
 -- >instance StoreData MyStore where
 -- >    type StoreAction MyStore = MyStoreAction

--- a/react-hs/src/React/Flux/Combinators.hs
+++ b/react-hs/src/React/Flux/Combinators.hs
@@ -1,7 +1,6 @@
 -- | This module contains some useful combinators I have come across as I built a large
 -- react-flux application.  None of these are required to use React.Flux, they just reduce somewhat
 -- the typing needed to create rendering functions.
-{-# LANGUAGE CPP, DeriveAnyClass #-}
 module React.Flux.Combinators (
     clbutton_
   , cldiv_
@@ -45,15 +44,17 @@ import GHCJS.Types (JSVal)
 -- >                       ]
 -- >        , callback "onChange" $ \(i :: String) -> dispatch $ ItemChangedTo i
 -- >        ]
-foreign_ :: JSString -- ^ this should be the name of a property on `window` which contains a react class.
+foreign_ :: forall handler a.
+            JSString -- ^ this should be the name of a property on `window` which contains a react class.
          -> [PropertyOrHandler handler] -- ^ properties
          -> ReactElementM handler a -- ^ children
          -> ReactElementM handler a
-foreign_ x = foreignClass (js_lookupWindow x)
+foreign_ x = foreignClass @handler (js_lookupWindow x)
 
 -- | Create a 'ReactElement' for a class defined in javascript.  See
 -- 'React.Flux.Combinators.foreign_' for a convenient wrapper and some examples.
-foreignClass :: JSVal -- ^ The javascript reference to the class
+foreignClass :: forall eventHandler a.
+                JSVal -- ^ The javascript reference to the class
              -> [PropertyOrHandler eventHandler] -- ^ properties and handlers to pass when creating an instance of this class.
              -> ReactElementM eventHandler a -- ^ The child element or elements
              -> ReactElementM eventHandler a
@@ -65,7 +66,8 @@ foreignClass name attrs (ReactElementM child) =
 -- be used as a last resort when interacting with complex third-party react classes.  For the most part,
 -- third-party react classes can be interacted with using 'foreignClass' and the various ways of creating
 -- properties.
-rawJsRendering :: (JSVal -> JSArray -> IO JSVal)
+rawJsRendering :: forall handler.
+                  (JSVal -> JSArray -> IO JSVal)
                   -- ^ The raw code to inject into the rendering function.  The first argument is the 'this' value
                   -- from the rendering function so points to the react class.  The second argument is the result of
                   -- rendering the children so is an array of react elements.  The return value must be a React element.
@@ -95,10 +97,10 @@ cldiv_ cl = div_ ["className" &= cl]
 -- >    faIcon_ "rocket"
 -- >    "Launch the missiles!"
 clbutton_ :: JSString  -- ^ class names separated by spaces
-          -> handler -- ^ the onClick handler for the button
+          -> EventHandlerType handler -- ^ the onClick handler for the button
           -> ReactElementM handler a -- ^ the children
           -> ReactElementM handler a
-clbutton_ cl h = button_ ["className" &= cl, onClick (\_ _ -> h)]
+clbutton_ cl h = button_ ["className" &= cl, onClick (\_ _ -> simpleHandler h)]
 
 -- | A 'label_' and an 'input_' together.  Useful for laying out forms.  For example, a
 -- stacked <http://purecss.io/forms/ Pure CSS Form> could be

--- a/react-hs/src/React/Flux/DOM.hs
+++ b/react-hs/src/React/Flux/DOM.hs
@@ -76,10 +76,12 @@ import Data.JSString (JSString)
 class Term label eventHandler arg result | result -> arg, result -> eventHandler where
     term :: label -> arg -> result
 
-instance (child ~ ReactElementM eventHandler a) => Term JSString eventHandler [PropertyOrHandler eventHandler] (child -> ReactElementM eventHandler a) where
+instance (child ~ ReactElementM_ eventHandler a, eventHandler ~ EventHandlerType handler)
+      => Term JSString eventHandler [PropertyOrHandler_ eventHandler] (child -> ReactElementM_ eventHandler a) where
     term name props = el name props
 
-instance Term JSString eventHandler (ReactElementM eventHandler a) (ReactElementM eventHandler a) where
+instance(eventHandler ~ EventHandlerType handler)
+      => Term JSString eventHandler (ReactElementM_ eventHandler a) (ReactElementM_ eventHandler a) where
     term name child = el name [] child
 
 term' :: Term JSString eventHandler arg result => JSString -> arg -> result

--- a/react-hs/src/React/Flux/Internal.hs
+++ b/react-hs/src/React/Flux/Internal.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE CPP, ViewPatterns #-}
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
-
 -- | Internal module for React.Flux
 --
 -- Normally you should not need to use anything in this module.  This module is only needed if you have
@@ -11,10 +8,13 @@ module React.Flux.Internal(
   , ReactElementRef(..)
   , ReactThis(..)
   , HandlerArg(..)
-  , PropertyOrHandler(..)
+  , PropertyOrHandler_(..)
+  , PropertyOrHandler
   , property
-  , ReactElement(..)
-  , ReactElementM(..)
+  , ReactElement_(..)
+  , ReactElement
+  , ReactElementM_(..)
+  , ReactElementM
   , transHandler
   , elemString
   , elemText
@@ -45,10 +45,11 @@ module React.Flux.Internal(
   , allEq
   , AllEq(..)
   , UnoverlapAllEq
+  , EventHandlerCode(..)
+  , EventHandlerType
 ) where
 
 import           Control.Exception (throwIO, ErrorCall(ErrorCall))
-import           Control.DeepSeq
 import           Data.String (IsString(..))
 import           Data.Aeson as A
 import           Data.Maybe (maybe)
@@ -84,7 +85,6 @@ instance IsJSVal ReactElementRef
 newtype HandlerArg = HandlerArg JSVal
   deriving (Generic)
 instance IsJSVal HandlerArg
-instance NFData HandlerArg
 
 -- | The this value during the rendering function
 newtype ReactThis state props = ReactThis {reactThisRef :: JSVal }
@@ -96,11 +96,33 @@ instance IsJSVal NewJsProps
 instance Show HandlerArg where
     show _ = "HandlerArg"
 
+-- | Event handler type codes to make things less polymorphic
+-- (we likely only ever need 'ViewEventHandler',
+-- 'StatefulViewEventHandler', so just throwing around unconstrained type variables is a little
+-- confusing).
+-- The terminology ...Code is used in literature like in
+-- http://www.larrytheliquid.com/drafts/leveling-up.pdf
+-- section 2.1 Example of a Martin-Löf universe
+data EventHandlerCode s = EventHandlerCode | StatefulEventHandlerCode s
+
+-- | Meanings of event handler type codes
+--
+-- Instances are defined in React.Flux.Views.
+--
+-- (This could be a closed type family but avoiding circular module imports is non-trivial.  One
+-- option would be to move this, PropertyOrHandler, but not PropertyOrHandler_, into
+-- PropertiesAndEvents. This would require a few more imports in various places, importing Store
+-- into PropertiesAndEvents and PropertiesAndEvents into DOM.
+-- https://github.com/liqula/react-hs/pull/25#issuecomment-313048580)
+type family EventHandlerType (x :: EventHandlerCode *) = r | r -> x
+
+type PropertyOrHandler a = PropertyOrHandler_ (EventHandlerType a)
+
 -- | Either a property or an event handler.
 --
 -- The combination of all properties and event handlers are used to create the javascript object
 -- passed as the second argument to @React.createElement@.
-data PropertyOrHandler handler =
+data PropertyOrHandler_ handler =
    forall ref. ToJSVal ref => Property
       { propertyName :: JSString
       , propertyVal :: ref
@@ -111,11 +133,11 @@ data PropertyOrHandler handler =
       }
  | NestedProperty
       { nestedPropertyName :: JSString
-      , nestedPropertyVals :: [PropertyOrHandler handler]
+      , nestedPropertyVals :: [PropertyOrHandler_ handler]
       }
  | ElementProperty
       { elementPropertyName :: JSString
-      , elementValue :: ReactElementM handler ()
+      , elementValue :: ReactElementM_ handler ()
       }
  | CallbackPropertyWithArgumentArray
       { caPropertyName :: JSString
@@ -123,7 +145,7 @@ data PropertyOrHandler handler =
       }
  | CallbackPropertyWithSingleArgument
       { csPropertyName :: JSString
-      , csFunc :: HandlerArg -> handler
+      , csFunc :: HandlerArg -> IO handler
       }
  | forall props. Typeable props => CallbackPropertyReturningView
       { cretPropertyName :: JSString
@@ -136,37 +158,39 @@ data PropertyOrHandler handler =
       , cretNewViewProps :: (JSArray -> IO NewJsProps)
       }
 
-instance Functor PropertyOrHandler where
+instance Functor PropertyOrHandler_ where
     fmap _ (Property name val) = Property name val
     fmap _ (PropertyFromContext name f) = PropertyFromContext name f
     fmap f (NestedProperty name vals) = NestedProperty name (map (fmap f) vals)
     fmap f (ElementProperty name (ReactElementM mkElem)) =
         ElementProperty name $ ReactElementM $ mapWriter (\((),e) -> ((), fmap f e)) mkElem
     fmap f (CallbackPropertyWithArgumentArray name h) = CallbackPropertyWithArgumentArray name (fmap f . h)
-    fmap f (CallbackPropertyWithSingleArgument name h) = CallbackPropertyWithSingleArgument name (f . h)
+    fmap f (CallbackPropertyWithSingleArgument name h) = CallbackPropertyWithSingleArgument name (fmap f . h)
     fmap _ (CallbackPropertyReturningView name f v) = CallbackPropertyReturningView name f v
     fmap _ (CallbackPropertyReturningNewView name v p) = CallbackPropertyReturningNewView name v p
 
 -- | Create a property from anything that can be converted to a JSVal
-property :: ToJSVal val => JSString -> val -> PropertyOrHandler handler
+property :: (ToJSVal val) => JSString -> val -> PropertyOrHandler handler
 property = Property
+
+type ReactElement a = ReactElement_ (EventHandlerType a)
 
 -- | A React element is a node or list of nodes in a virtual tree.  Elements are the output of the
 -- rendering functions of classes.  React takes the output of the rendering function (which is a
 -- tree of elements) and then reconciles it with the actual DOM elements in the browser.  The
 -- 'ReactElement' is a monoid, so dispite its name can represent more than one element.  Multiple
 -- elements are rendered into the browser DOM as siblings.
-data ReactElement eventHandler
+data ReactElement_ (eventHandler :: *)
     = ForeignElement
         { fName :: Either JSString (ReactViewRef Object)
-        , fProps :: [PropertyOrHandler eventHandler]
-        , fChild :: ReactElement eventHandler
+        , fProps :: [PropertyOrHandler_ eventHandler]
+        , fChild :: ReactElement_ eventHandler
         }
     | forall props. Typeable props => ViewElement
         { ceClass :: ReactViewRef props
         , ceKey :: Maybe JSVal
         , ceProps :: props
-        , ceChild :: ReactElement eventHandler
+        , ceChild :: ReactElement_ eventHandler
         }
     | NewViewElement
         { newClass :: ReactViewRef ()
@@ -176,18 +200,18 @@ data ReactElement eventHandler
     | RawJsElement
         { rawTransform :: JSVal -> [ReactElementRef] -> IO ReactElementRef
         -- ^ first arg is this from render method, second argument is the rendering of 'rawChild'
-        , rawChild :: ReactElement eventHandler
+        , rawChild :: ReactElement_ eventHandler
         }
     | ChildrenPassedToView
     | Content JSString
-    | Append (ReactElement eventHandler) (ReactElement eventHandler)
+    | Append (ReactElement_ eventHandler) (ReactElement_ eventHandler)
     | EmptyElement
 
-instance Monoid (ReactElement eventHandler) where
+instance Monoid (ReactElement_ eventHandler) where
     mempty = EmptyElement
     mappend x y = Append x y
 
-instance Functor ReactElement where
+instance Functor ReactElement_ where
     fmap f (ForeignElement n p c) = ForeignElement n (map (fmap f) p) (fmap f c)
     fmap f (ViewElement n k p c) = ViewElement n k p (fmap f c)
     fmap _ (NewViewElement n k p) = NewViewElement n k p
@@ -220,25 +244,27 @@ instance Functor ReactElement where
 -- ></ul>
 --
 -- The "React.Flux.DOM" module contains a large number of combinators for creating HTML elements.
-newtype ReactElementM eventHandler a = ReactElementM { runReactElementM :: Writer (ReactElement eventHandler) a }
+type ReactElementM e a = ReactElementM_ (EventHandlerType e) a
+
+newtype ReactElementM_ eventHandler a = ReactElementM { runReactElementM :: Writer (ReactElement_ eventHandler) a }
     deriving (Functor, Applicative, Monad, Foldable)
 
 -- | Create a 'ReactElementM' containing a given 'ReactElement'.
-elementToM :: a -> ReactElement eventHandler -> ReactElementM eventHandler a
+elementToM :: a -> ReactElement_ eventHandler -> ReactElementM_ eventHandler a
 elementToM a e = ReactElementM (WriterT (Identity (a, e)))
 
-instance (a ~ ()) => Monoid (ReactElementM eventHandler a) where
+instance (a ~ ()) => Monoid (ReactElementM_ eventHandler a) where
     mempty = elementToM () EmptyElement
     mappend e1 e2 =
         let ((),e1') = runWriter $ runReactElementM e1
             ((),e2') = runWriter $ runReactElementM e2
          in elementToM () $ Append e1' e2'
 
-instance (a ~ ()) => IsString (ReactElementM eventHandler a) where
+instance (a ~ ()) => IsString (ReactElementM_ eventHandler a) where
     fromString s = elementToM () $ Content $ toJSString s
 
 -- | Transform the event handler for a 'ReactElementM'.
-transHandler :: (handler1 -> handler2) -> ReactElementM handler1 a -> ReactElementM handler2 a
+transHandler :: (handler1 -> handler2) -> ReactElementM_ handler1 a -> ReactElementM_ handler2 a
 transHandler f (ReactElementM w) = ReactElementM $ mapWriter f' w
   where
     f' (a, x) = (a, fmap f x)
@@ -261,7 +287,7 @@ elemJSString s = elementToM () $ Content s
 
 -- | Create an element containing text which is the result of 'show'ing the argument.
 -- Note that the resulting string is then escaped to be HTML safe.
-elemShow :: Show a => a -> ReactElementM eventHandler ()
+elemShow :: (Show a) => a -> ReactElementM eventHandler ()
 elemShow s = elementToM () $ Content $ toJSString $ show s
 
 -- | Create a React element.
@@ -289,14 +315,14 @@ type CallbackToRelease = JSVal
 -- to nodes within the element.  These callbacks will need to be released with 'releaseCallback'
 -- once the class is re-rendered.
 mkReactElement :: forall eventHandler state props.
-                  (eventHandler -> IO ())
+                  (EventHandlerType eventHandler -> IO ())
                -> ReactThis state props -- ^ this
                -> ReactElementM eventHandler ()
                -> IO (ReactElementRef, [CallbackToRelease])
 mkReactElement runHandler this = runWriterT . mToElem runHandler this
 
 -- Run the ReactElementM monad to create a ReactElementRef.
-mToElem :: (eventHandler -> IO ()) -> ReactThis state props -> ReactElementM eventHandler () -> MkReactElementM ReactElementRef
+mToElem :: (EventHandlerType eventHandler -> IO ()) -> ReactThis state props -> ReactElementM eventHandler () -> MkReactElementM ReactElementRef
 mToElem runHandler this eM = do
     let e = execWriter $ runReactElementM eM
         e' = case e of
@@ -312,7 +338,11 @@ mToElem runHandler this eM = do
             js_ReactCreateForeignElement (ReactViewRef js_divLikeElement) emptyObj arr
 
 -- add the property or handler to the javascript object
-addPropOrHandlerToObj :: (eventHandler -> IO ()) -> ReactThis state props -> JSO.Object -> PropertyOrHandler eventHandler -> MkReactElementM ()
+addPropOrHandlerToObj :: (EventHandlerType eventHandler -> IO ())
+                      -> ReactThis state props
+                      -> JSO.Object
+                      -> PropertyOrHandler eventHandler
+                      -> MkReactElementM ()
 addPropOrHandlerToObj _ _ obj (Property n val) = lift $ do
     vRef <- toJSVal val
     JSO.setProp n vRef obj
@@ -343,7 +373,7 @@ addPropOrHandlerToObj runHandler _ obj (CallbackPropertyWithArgumentArray name f
 addPropOrHandlerToObj runHandler _ obj (CallbackPropertyWithSingleArgument name func) = do
     -- this will be released by the render function of the class (jsbits/class.js)
     cb <- lift $ syncCallback1 ContinueAsync $ \ref ->
-        runHandler $ func $ HandlerArg ref
+        runHandler =<< func (HandlerArg ref)
     tell [jsval cb]
     lift $ JSO.setProp name (jsval cb) obj
 
@@ -361,7 +391,7 @@ addPropOrHandlerToObj _ _ obj (CallbackPropertyReturningNewView name v toProps) 
 type MkReactElementM a = WriterT [CallbackToRelease] IO a
 
 -- | call React.createElement
-createElement :: (eventHandler -> IO ()) -> ReactThis state props -> ReactElement eventHandler -> MkReactElementM [ReactElementRef]
+createElement :: (EventHandlerType eventHandler -> IO ()) -> ReactThis state props -> ReactElement eventHandler -> MkReactElementM [ReactElementRef]
 createElement _ _ EmptyElement = return []
 createElement runHandler this (Append x y) = (++) <$> createElement runHandler this x <*> createElement runHandler this y
 createElement _ _ (Content s) = return [js_ReactCreateContent s]
@@ -451,7 +481,7 @@ n &= a = Property n a
 infixr 0 &=
 
 -- | Create a property from any aeson value (the at sign looks like "A" for aeson)
-(@=) :: A.ToJSON a => JSString -> a -> PropertyOrHandler handler
+(@=) :: (A.ToJSON a) => JSString -> a -> PropertyOrHandler handler
 n @= a = Property n (A.toJSON a)
 infixr 0 @=
 
@@ -523,36 +553,28 @@ singleEq_ Proxy (fakeJSValToExport -> (jsa :: Export t)) (fakeJSValToExport -> (
 allEq :: AllEq t => Proxy t -> IO (Callback ForeignEq)
 allEq proxy = syncCallback2' (\jsa jsb -> toJSVal =<< allEq_ proxy 0 jsa jsb)
 
+type family StoreType a where
+  StoreType (StoreArg st) = st
+  StoreType (StoreField st fn ft) = ft
+  StoreType a = a
+
 class AllEq t where
   allEq_ :: Proxy t -> Int -> ForeignEq_
 
 instance AllEq '[] where
   allEq_ Proxy _ _ _ = pure True
 
-instance {-# OVERLAPPING #-} (Typeable st, Eq st, AllEq ts)
-      => AllEq (StoreArg st ': ts) where
-  allEq_ Proxy = allEq__ (Proxy :: Proxy (st ': ts))
+instance (Typeable (StoreType t), Eq (StoreType t), AllEq ts)
+      => AllEq (t ': ts) where
+  allEq_ Proxy i jsas jsbs = do
+    let jsa = js_findFromArray i jsas
+        jsb = js_findFromArray i jsbs
+    (&&) <$> singleEq_ (Proxy :: Proxy (StoreType t)) jsa jsb
+         <*> allEq_    (Proxy :: Proxy ts) (i + 1) jsas jsbs
 
-instance {-# OVERLAPPING #-} (Typeable ft, Eq ft, AllEq ts)
-      => AllEq (StoreField st fn ft ': ts) where
-  allEq_ Proxy = allEq__ (Proxy :: Proxy (ft ': ts))
 
-instance {-# OVERLAPPABLE #-} (Typeable t, Eq t, UnoverlapAllEq t, AllEq ts) => AllEq (t ': ts) where
-  allEq_ = allEq__
-
--- | Trick class for disambiguating 'AllEq' instances.  If you need an 'AllEq' instance for a type
--- list, and that type list has a type element not wrapped by 'StoreArg' or 'StoreField', declare an
--- empty ("marker") instance of this class for the element type.
---
--- FUTUREWORK: there is probably a nicer solution than this.  go find it!
+{-# DEPRECATED UnoverlapAllEq "not required any more, just remove the instance." #-}
 class UnoverlapAllEq t
-
-allEq__ :: forall t ts. (Typeable t, Eq t, AllEq ts) => Proxy (t ': ts) -> Int -> ForeignEq_
-allEq__ Proxy i jsas jsbs = do
-  let jsa = js_findFromArray i jsas
-      jsb = js_findFromArray i jsbs
-  (&&) <$> singleEq_ (Proxy :: Proxy t)  jsa jsb
-       <*> allEq_    (Proxy :: Proxy ts) (i + 1) jsas jsbs
 
 #ifdef __GHCJS__
 

--- a/react-hs/src/React/Flux/Outdated.hs
+++ b/react-hs/src/React/Flux/Outdated.hs
@@ -1,6 +1,4 @@
 -- | Internal module containing the view definitions
-{-# LANGUAGE CPP, UndecidableInstances, TypeApplications, MagicHash #-}
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 module React.Flux.Outdated
   ( SomeStoreAction(..)
   , ReactView
@@ -23,14 +21,10 @@ module React.Flux.Outdated
   , LPropsAndState(..)
   , LDOM(..)
   , LSetStateFn
-  , reactRender
-  , reactRenderToString
   ) where
 
 import Control.Monad.Writer
 import Data.Typeable
-import Control.DeepSeq
-import Data.Text
 
 import React.Flux.Store
 import React.Flux.Internal
@@ -67,7 +61,7 @@ newtype ReactView props = ReactView { reactView :: ReactViewRef props }
 
 
 -- | Transform a stateful view event handler to a raw event handler
-runStateViewHandler :: (Typeable state, NFData state)
+runStateViewHandler :: (Typeable state)
                     => ReactThis state props -> StatefulViewEventHandler state -> IO ()
 runStateViewHandler this handler = do
     st <- js_ReactGetState this >>= unsafeDerefExport "runStateViewHandler"
@@ -77,12 +71,10 @@ runStateViewHandler this handler = do
     case mNewState of
         Nothing -> return ()
         Just newState -> do
-            newStateRef <- newState `deepseq` export newState
+            newStateRef <- export newState
             js_ReactUpdateAndReleaseState this newStateRef
 
-    -- nothing above here should block, so the handler callback should still be running syncronous,
-    -- so the deepseq of actions should still pick up the proper event object.
-    actions `deepseq` mapM_ executeAction actions
+    executeAction `mapM_` actions
 
 
 ---------------------------------------------------------------------------------------------------
@@ -92,9 +84,9 @@ runStateViewHandler this handler = do
 newtype RenderCbArg = RenderCbArg JSVal
 instance IsJSVal RenderCbArg
 
-mkRenderCallback :: Typeable props
+mkRenderCallback :: forall props state eventHandler. (Typeable props)
                  => (ReactThis state props -> IO state) -- ^ parse state
-                 -> (ReactThis state props -> eventHandler -> IO ()) -- ^ execute event args
+                 -> (ReactThis state props -> EventHandlerType eventHandler -> IO ()) -- ^ execute event args
                  -> (state -> props -> IO (ReactElementM eventHandler ())) -- ^ renderer
                  -> IO (Callback (JSVal -> JSVal -> IO ()))
 mkRenderCallback parseState runHandler render = syncCallback2 ContinueAsync $ \thisRef argRef -> do
@@ -103,7 +95,7 @@ mkRenderCallback parseState runHandler render = syncCallback2 ContinueAsync $ \t
     state <- parseState this
     props <- js_ReactGetProps this >>= unsafeDerefExport "mkRenderCallback"
     node <- render state props
-    (element, evtCallbacks) <- mkReactElement (runHandler this) this node
+    (element, evtCallbacks) <- mkReactElement @eventHandler (runHandler this) this node
 
     evtCallbacksRef <- toJSVal evtCallbacks
     js_RenderCbSetResults arg evtCallbacksRef element
@@ -115,7 +107,7 @@ mkRenderCallback parseState runHandler render = syncCallback2 ContinueAsync $ \t
 
 -- | Create an element from a view.  I suggest you make a combinator for each of your views, similar
 -- to the examples above such as @todoItem_@.
-view :: Typeable props
+view :: forall props eventHandler a. (Typeable props)
      => ReactView props -- ^ the view
      -> props -- ^ the properties to pass into the instance of this view
      -> ReactElementM eventHandler a -- ^ The children of the element
@@ -135,7 +127,7 @@ instance ReactViewKey Int where
 
 -- | A deprecated way to create a view with a key which has problems when OverloadedStrings is
 -- active.  Use 'viewWithSKey' or 'viewWithIKey' instead.
-viewWithKey :: (Typeable props, ReactViewKey key)
+viewWithKey :: forall props key eventHandler a. (Typeable props, ReactViewKey key)
             => ReactView props -- ^ the view
             -> key -- ^ A value unique within the siblings of this element
             -> props -- ^ The properties to pass to the view instance
@@ -149,7 +141,7 @@ viewWithKey rc key props (ReactElementM child) =
 -- properties speed up the <https://facebook.github.io/react/docs/reconciliation.html reconciliation>
 -- of the virtual DOM with the DOM.  The key does not need to be globally unqiue, it only needs to
 -- be unique within the siblings of an element.
-viewWithSKey :: Typeable props
+viewWithSKey :: forall props eventHandler a. (Typeable props)
              => ReactView props -- ^ the view
              -> JSString -- ^ The key, a value unique within the siblings of this element
              -> props -- ^ The properties to pass to the view instance
@@ -160,7 +152,7 @@ viewWithSKey rc key props (ReactElementM child) =
      in elementToM a $ ViewElement (reactView rc) (Just $ pToJSVal key) props childEl
 
 -- | Similar to 'viewWithSKey', but with an integer key instead of a string key.
-viewWithIKey :: Typeable props
+viewWithIKey :: forall props eventHandler a. (Typeable props)
              => ReactView props -- ^ the view
              -> Int -- ^ The key, a value unique within the siblings of this element
              -> props -- ^ The properties to pass to the view instance
@@ -325,7 +317,7 @@ type LSetStateFn state = state -> IO ()
 -- events.  As mentioned above, care must be taken in each callback to write only IO that will not
 -- block.
 data LifecycleViewConfig props state = LifecycleViewConfig
-  { lRender :: state -> props -> ReactElementM (StatefulViewEventHandler state) ()
+  { lRender :: state -> props -> ReactElementM ('StatefulEventHandlerCode state) ()
   , lComponentWillMount :: Maybe (LPropsAndState props state -> LSetStateFn state -> IO ())
   , lComponentDidMount :: Maybe (LPropsAndState props state -> LDOM -> LSetStateFn state -> IO ())
   -- | Receives the new props as an argument.
@@ -360,7 +352,7 @@ lifecycleConfig = LifecycleViewConfig
 -- >            , lComponentWillMount = \propsAndState setStateFn -> ...
 -- >            }
 {-# NOINLINE defineLifecycleView #-}
-defineLifecycleView :: forall props state . (Typeable props, Eq props, Typeable state, NFData state, Eq state)
+defineLifecycleView :: forall props state . (Typeable props, Eq props, Typeable state, Eq state)
               => String -> state -> LifecycleViewConfig props state -> ReactView props
 
 defineLifecycleView name initialState cfg = unsafePerformIO $ do
@@ -443,46 +435,6 @@ mkLCallback2 (Just f) c = do
   return $ jsval cb
 
 
-----------------------------------------------------------------------------------------------------
--- reactRender has two versions
-----------------------------------------------------------------------------------------------------
-
--- | Render your React application into the DOM.  Use this from your @main@ function, and only in the browser.
--- 'reactRender' only works when compiled with GHCJS (not GHC), because we rely on the React javascript code
--- to actually perform the rendering.
-reactRender :: Typeable props
-            => String -- ^ The ID of the HTML element to render the application into.
-                      -- (This string is passed to @document.getElementById@)
-            -> ReactView props -- ^ A single instance of this view is created
-            -> props -- ^ the properties to pass to the view
-            -> IO ()
-reactRender htmlId rc props = do
-    (e, _) <- mkReactElement id (ReactThis nullRef) $ view rc props mempty
-    js_ReactRender e (toJSString htmlId)
-
--- | Render your React application to a string using either @ReactDOMServer.renderToString@ if the first
--- argument is false or @ReactDOMServer.renderToStaticMarkup@ if the first argument is true.
--- Use this only on the server when running with node.
--- 'reactRenderToString' only works when compiled with GHCJS (not GHC), because we rely on the React javascript code
--- to actually perform the rendering.
---
--- If you are interested in isomorphic React, I suggest instead of using 'reactRenderToString' you use
--- 'exportViewToJavaScript' and then write a small top-level JavaScript view which can then integrate with
--- all the usual isomorphic React tools.
-reactRenderToString :: Typeable props
-                    => Bool -- ^ Render to static markup?  If true, this won't create extra DOM attributes
-                            -- that React uses internally.
-                    -> ReactView props -- ^ A single instance of this view is created
-                    -> props -- ^ the properties to pass to the view
-                    -> IO Text
-reactRenderToString includeStatic rc props = do
-    (e, _) <- mkReactElement id (ReactThis nullRef) $ view rc props mempty
-    sRef <- (if includeStatic then js_ReactRenderStaticMarkup else js_ReactRenderToString) e
-    --return sRef
-    --return $ JSS.unpack sRef
-    mtxt <- fromJSVal sRef
-    maybe (error "Unable to convert string return to Text") return mtxt
-
 #ifdef __GHCJS__
 
 foreign import javascript unsafe
@@ -519,18 +471,6 @@ foreign import javascript unsafe
     "typeof ReactDOM === 'object' ? $1['refs'][$2] : React['findDOMNode']($1['refs'][$2])"
     js_ReactGetRef :: ReactThis state props -> JSString -> IO JSVal
 
-foreign import javascript unsafe
-    "(typeof ReactDOM === 'object' ? ReactDOM : React)['render']($1, document.getElementById($2))"
-    js_ReactRender :: ReactElementRef -> JSString -> IO ()
-
-foreign import javascript unsafe
-    "(typeof ReactDOMServer === 'object' ? ReactDOMServer : (typeof ReactDOM === 'object' ? ReactDOM : React))['renderToString']($1)"
-    js_ReactRenderToString :: ReactElementRef -> IO JSVal
-
-foreign import javascript unsafe
-    "(typeof ReactDOMServer === 'object' ? ReactDOMServer : (typeof ReactDOM === 'object' ? ReactDOM : React))['renderToStaticMarkup']($1)"
-    js_ReactRenderStaticMarkup :: ReactElementRef -> IO JSVal
-
 #else
 
 js_ReactGetState :: ReactThis state props -> IO (Export state)
@@ -559,14 +499,5 @@ js_ReactFindDOMNode _ = error "js_ReactFindDOMNode only works with GHCJS"
 
 js_ReactGetRef :: ReactThis state props -> JSString -> IO JSVal
 js_ReactGetRef _ _ = error "js_ReactGetRef only works with GHCJS"
-
-js_ReactRender :: ReactElementRef -> JSString -> IO ()
-js_ReactRender _ _ = error "js_ReactRender only works with GHCJS"
-
-js_ReactRenderToString :: ReactElementRef -> IO JSVal
-js_ReactRenderToString _ = error "js_ReactRenderToString only works with GHCJS"
-
-js_ReactRenderStaticMarkup :: ReactElementRef -> IO JSVal
-js_ReactRenderStaticMarkup _ = error "js_ReactRenderStaticMarkup only works with GHCJS"
 
 #endif

--- a/react-hs/src/React/Flux/PropertiesAndEvents.hs
+++ b/react-hs/src/React/Flux/PropertiesAndEvents.hs
@@ -1,9 +1,9 @@
 -- | This module contains the definitions for creating properties to pass to javascript elements and
 -- foreign javascript classes.  In addition, it contains definitions for the
 -- <https://facebook.github.io/react/docs/events.html React Event System>.
-{-# LANGUAGE CPP, ViewPatterns, UndecidableInstances #-}
 module React.Flux.PropertiesAndEvents (
     PropertyOrHandler
+  , EventHandlerTypeWithMods
 
   -- * Creating Properties
   , property
@@ -25,6 +25,8 @@ module React.Flux.PropertiesAndEvents (
   , EventTarget(..)
   , eventTargetProp
   , target
+  , EventModification(..)
+  , simpleHandler
   , preventDefault
   , stopPropagation
   , capturePhase
@@ -89,7 +91,6 @@ module React.Flux.PropertiesAndEvents (
 ) where
 
 import           Control.Monad (forM)
-import           Control.DeepSeq
 import           System.IO.Unsafe (unsafePerformIO)
 import           Data.Monoid ((<>))
 import qualified Data.Text as T
@@ -106,6 +107,8 @@ import           GHCJS.Types (JSVal, nullRef, IsJSVal)
 import           JavaScript.Array as JSA
 import qualified Data.JSString.Text as JSS
 
+
+type EventHandlerTypeWithMods code = (EventHandlerType code, [EventModification])
 
 -- | Some third-party React classes allow passing React elements as properties.  This function
 -- will first run the given 'ReactElementM' to obtain an element or elements, and then use that
@@ -164,7 +167,7 @@ instance {-# OVERLAPPABLE #-} (FromJSVal a, CallbackFunction handler b) => Callb
 -- >baz :: ViewEventHandler
 --
 -- For another example, see the haddock comments in "React.Flux.Addons.Bootstrap".
-callback :: CallbackFunction handler func => JSString -> func -> PropertyOrHandler handler
+callback :: CallbackFunction (EventHandlerType handler) func => JSString -> func -> PropertyOrHandler handler
 callback name func = CallbackPropertyWithArgumentArray name $ \arr -> applyFromArguments arr 0 func
 
 
@@ -177,7 +180,6 @@ callback name func = CallbackPropertyWithArgumentArray name $ \arr -> applyFromA
 newtype EventTarget = EventTarget JSVal
   deriving (Generic)
 instance IsJSVal EventTarget
-instance NFData EventTarget
 
 instance Show (EventTarget) where
     show _ = "EventTarget"
@@ -200,8 +202,6 @@ data Event = Event
     , evtTimestamp :: Int
     , evtHandlerArg :: HandlerArg
     } deriving (Show, Generic)
-
-instance NFData Event
 
 -- | A version of 'eventTargetProp' which accesses the property of 'evtTarget' in the event.  This
 -- is useful for example:
@@ -232,42 +232,65 @@ parseEvent arg@(HandlerArg o) = Event
 -- | Use this to create an event handler for an event not covered by the rest of this module.
 -- (Events are not covered if they don't have extra arguments that require special handling.)
 -- For example, onPlay and onPause are events you could use with @on@.
-on :: JSString -> (Event -> handler) -> PropertyOrHandler handler
+on :: JSString -> (Event -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 on name f = CallbackPropertyWithSingleArgument
     { csPropertyName = name
-    , csFunc = f . parseEvent
+    , csFunc = runEvent $ f . parseEvent
     }
 
 -- | Construct a handler from a detail parser, used by the various events below.
 on2 :: JSString -- ^ The event name
     -> (HandlerArg -> detail) -- ^ A function parsing the details for the specific event.
-    -> (Event -> detail -> handler) -- ^ The function implementing the handler.
+    -> (Event -> detail -> EventHandlerTypeWithMods handler) -- ^ The function implementing the handler.
     -> PropertyOrHandler handler
 on2 name parseDetail f = CallbackPropertyWithSingleArgument
     { csPropertyName = name
-    , csFunc = \raw -> f (parseEvent raw) (parseDetail raw)
+    , csFunc = runEvent $ \raw -> f (parseEvent raw) (parseDetail raw)
     }
 
--- | React re-uses event objects in a pool.  To make sure this is OK, we must perform
--- all computation involving the event object before it is returned to React.  But the callback
--- registered in the handler will return anytime the Haskell thread blocks, and the Haskell thread
--- will continue asynchronously.  If this occurs, the event object is no longer valid.  This
--- therefore needs to be called and fully processed in the handler before anything else happens,
--- like sending actions to stores.
---
--- TODO: this requires some more reasoning that would show that it actually works.  It may be
--- possible that there still is room for the thread to yield between receiving the handler object
--- and executing the 'unsafePerformIO' in here, even if it is called first thing in the handler
--- body.
---
--- FIXME: A better way may be to make a specialized monad available in the event handlers that
--- allows for these things, but not general IO.
-preventDefault :: Event -> ()
-preventDefault (evtHandlerArg -> HandlerArg ref) = unsafePerformIO (js_preventDefault ref) `seq` ()
+runEvent :: (HandlerArg -> EventHandlerTypeWithMods handler) -> (HandlerArg -> IO (EventHandlerType handler))
+runEvent f raw = do
+  js_persistReactEvent raw
+  let (acts, mods) = f raw
+  runEventModifications raw mods
+  pure acts
+  where
+    runEventModifications :: HandlerArg -> [EventModification] -> IO ()
+    runEventModifications (HandlerArg ev) = mapM_ $ \case
+      PreventDefault  -> js_preventDefault ev
+      StopPropagation -> js_stopPropagation ev
 
--- | See 'preventDefault'.
-stopPropagation :: Event -> ()
-stopPropagation (evtHandlerArg -> HandlerArg ref) = unsafePerformIO (js_stopPropagation ref) `seq` ()
+-- | (This is morally an internal type with only 'simpleEvent', 'preventDefault', 'stopPropagation'
+-- being allowed to use it.  It's still ok to use it for hacking, see 'simpleHandler'.)
+data EventModification = PreventDefault | StopPropagation
+  deriving (Eq, Show)
+
+-- | Event propagation is controlled by registering a list of 'EventModification's with the handler.
+-- The handler author can only do that with the functions 'simpleHandler', 'preventDefault',
+-- 'stopPropagation'.  This adds a list of modifications to the handler that is interpreted by
+-- 'runEvent'.
+--
+-- The reason this cannot be done locally in the event handler callbacks is that those callbacks are
+-- pure, and applying an event modifier is an effect.  (This was perviously solved by using `seq`
+-- and `deepseq` in (hopefully all of) the right places and then executing the effect in
+-- 'unsafePerformIO'.  An even better solution than the current one may be to give the callbacks
+-- monadic result types.  Then we could move the modifiers from the result tuple into a writer
+-- monad.  See #6.)
+--
+-- If you need more event modifiers, or if you need to be able to apply more than one of them,
+-- please <https://github.com/liqula/react-hs open an issue>.  You can do this manually to an extent
+-- ('EventModification' is exported for now), but we would like to have a use case justifying a
+-- better way of dealing with for event modifiers.
+simpleHandler :: h -> (h, [EventModification])
+simpleHandler = (, [])
+
+-- | See 'simpleHandler'.
+preventDefault :: h -> (h, [EventModification])
+preventDefault = (, [PreventDefault])
+
+-- | See 'simpleHandler'.
+stopPropagation :: h -> (h, [EventModification])
+stopPropagation = (, [StopPropagation])
 
 -- | By default, the handlers below are triggered during the bubbling phase.  Use this to switch
 -- them to trigger during the capture phase.
@@ -297,7 +320,6 @@ data KeyboardEvent = KeyboardEvent
   }
   deriving (Generic)
 
-instance NFData KeyboardEvent
 instance Show KeyboardEvent where
     show (KeyboardEvent k1 k2 k3 _ k4 k5 k6 k7 k8 k9 k10 k11) =
         show (k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11)
@@ -318,13 +340,13 @@ parseKeyboardEvent (HandlerArg o) = KeyboardEvent
     , keyWhich = o .: "which"
     }
 
-onKeyDown :: (Event -> KeyboardEvent -> handler) -> PropertyOrHandler handler
+onKeyDown :: (Event -> KeyboardEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onKeyDown = on2 "onKeyDown" parseKeyboardEvent
 
-onKeyPress :: (Event -> KeyboardEvent -> handler) -> PropertyOrHandler handler
+onKeyPress :: (Event -> KeyboardEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onKeyPress = on2 "onKeyPress" parseKeyboardEvent
 
-onKeyUp :: (Event -> KeyboardEvent -> handler) -> PropertyOrHandler handler
+onKeyUp :: (Event -> KeyboardEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onKeyUp = on2 "onKeyUp" parseKeyboardEvent
 
 --------------------------------------------------------------------------------
@@ -338,10 +360,10 @@ data FocusEvent = FocusEvent {
 parseFocusEvent :: HandlerArg -> FocusEvent
 parseFocusEvent (HandlerArg ref) = FocusEvent $ EventTarget $ js_getProp ref "relatedTarget"
 
-onBlur :: (Event -> FocusEvent -> handler) -> PropertyOrHandler handler
+onBlur :: (Event -> FocusEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onBlur = on2 "onBlur" parseFocusEvent
 
-onFocus :: (Event -> FocusEvent -> handler) -> PropertyOrHandler handler
+onFocus :: (Event -> FocusEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onFocus = on2 "onFocus" parseFocusEvent
 
 --------------------------------------------------------------------------------
@@ -350,13 +372,13 @@ onFocus = on2 "onFocus" parseFocusEvent
 
 -- | The onChange event is special in React and should be used for all input change events.  For
 -- details, see <https://facebook.github.io/react/docs/forms.html>
-onChange :: (Event -> handler) -> PropertyOrHandler handler
+onChange :: (Event -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onChange = on "onChange"
 
-onInput :: (Event -> handler) -> PropertyOrHandler handler
+onInput :: (Event -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onInput = on "onInput"
 
-onSubmit :: (Event -> handler) -> PropertyOrHandler handler
+onSubmit :: (Event -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onSubmit = on "onSubmit"
 
 --------------------------------------------------------------------------------
@@ -381,7 +403,6 @@ data MouseEvent = MouseEvent
   }
   deriving (Generic)
 
-instance NFData MouseEvent
 instance Show MouseEvent where
     show (MouseEvent m1 m2 m3 m4 m5 m6 _ m7 m8 m9 m10 m11 m12 m13)
         = show (m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13)
@@ -404,58 +425,58 @@ parseMouseEvent (HandlerArg o) = MouseEvent
     , mouseShiftKey = o .: "shiftKey"
     }
 
-onClick :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onClick :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onClick = on2 "onClick" parseMouseEvent
 
-onContextMenu :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onContextMenu :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onContextMenu = on2 "onContextMenu" parseMouseEvent
 
-onDoubleClick :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDoubleClick :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDoubleClick = on2 "onDoubleClick" parseMouseEvent
 
-onDrag :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDrag :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDrag = on2 "onDrag" parseMouseEvent
 
-onDragEnd :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDragEnd :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDragEnd = on2 "onDragEnd" parseMouseEvent
 
-onDragEnter :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDragEnter :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDragEnter = on2 "onDragEnter" parseMouseEvent
 
-onDragExit :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDragExit :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDragExit = on2 "onDragExit" parseMouseEvent
 
-onDragLeave :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDragLeave :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDragLeave = on2 "onDragLeave" parseMouseEvent
 
-onDragOver :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDragOver :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDragOver = on2 "onDragOver" parseMouseEvent
 
-onDragStart :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDragStart :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDragStart = on2 "onDragStart" parseMouseEvent
 
-onDrop :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onDrop :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onDrop = on2 "onDrop" parseMouseEvent
 
-onMouseDown :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onMouseDown :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onMouseDown = on2 "onMouseDown" parseMouseEvent
 
-onMouseEnter :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onMouseEnter :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onMouseEnter = on2 "onMouseEnter" parseMouseEvent
 
-onMouseLeave :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onMouseLeave :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onMouseLeave = on2 "onMouseLeave" parseMouseEvent
 
-onMouseMove :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onMouseMove :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onMouseMove = on2 "onMouseMove" parseMouseEvent
 
-onMouseOut :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onMouseOut :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onMouseOut = on2 "onMouseOut" parseMouseEvent
 
-onMouseOver :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onMouseOver :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onMouseOver = on2 "onMouseOver" parseMouseEvent
 
-onMouseUp :: (Event -> MouseEvent -> handler) -> PropertyOrHandler handler
+onMouseUp :: (Event -> MouseEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onMouseUp = on2 "onMouseUp" parseMouseEvent
 
 --------------------------------------------------------------------------------
@@ -473,8 +494,6 @@ data Touch = Touch {
   , touchPageY :: Int
 } deriving (Show, Generic)
 
-instance NFData Touch
-
 data TouchEvent = TouchEvent {
     touchAltKey :: Bool
   , changedTouches :: [Touch]
@@ -486,8 +505,6 @@ data TouchEvent = TouchEvent {
   , touches :: [Touch]
   }
   deriving (Generic)
-
-instance NFData TouchEvent
 
 instance Show TouchEvent where
     show (TouchEvent t1 t2 t3 _ t4 t5 t6 t7)
@@ -512,6 +529,7 @@ parseTouchList obj key = unsafePerformIO $ do
     forM [0..len-1] $ \idx -> do
         let jsref = arrayIndex idx arr
         return $ parseTouch jsref
+
 parseTouchEvent :: HandlerArg -> TouchEvent
 parseTouchEvent (HandlerArg o) = TouchEvent
     { touchAltKey = o .: "altKey"
@@ -524,23 +542,23 @@ parseTouchEvent (HandlerArg o) = TouchEvent
     , touches = parseTouchList o "touches"
     }
 
-onTouchCancel :: (Event -> TouchEvent -> handler) -> PropertyOrHandler handler
+onTouchCancel :: (Event -> TouchEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onTouchCancel = on2 "onTouchCancel" parseTouchEvent
 
-onTouchEnd :: (Event -> TouchEvent -> handler) -> PropertyOrHandler handler
+onTouchEnd :: (Event -> TouchEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onTouchEnd = on2 "onTouchEnd" parseTouchEvent
 
-onTouchMove :: (Event -> TouchEvent -> handler) -> PropertyOrHandler handler
+onTouchMove :: (Event -> TouchEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onTouchMove = on2 "onTouchMove" parseTouchEvent
 
-onTouchStart :: (Event -> TouchEvent -> handler) -> PropertyOrHandler handler
+onTouchStart :: (Event -> TouchEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onTouchStart = on2 "onTouchStart" parseTouchEvent
 
 --------------------------------------------------------------------------------
 -- UI Events
 --------------------------------------------------------------------------------
 
-onScroll :: (Event -> handler) -> PropertyOrHandler handler
+onScroll :: (Event -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onScroll = on "onScroll"
 
 --------------------------------------------------------------------------------
@@ -554,8 +572,6 @@ data WheelEvent = WheelEvent {
   , wheelDeltaZ :: Int
 } deriving (Show, Generic)
 
-instance NFData WheelEvent
-
 parseWheelEvent :: HandlerArg -> WheelEvent
 parseWheelEvent (HandlerArg o) = WheelEvent
     { wheelDeltaMode = o .: "deltaMode"
@@ -564,20 +580,20 @@ parseWheelEvent (HandlerArg o) = WheelEvent
     , wheelDeltaZ = o .: "deltaZ"
     }
 
-onWheel :: (Event -> MouseEvent -> WheelEvent -> handler) -> PropertyOrHandler handler
+onWheel :: (Event -> MouseEvent -> WheelEvent -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onWheel f = CallbackPropertyWithSingleArgument
     { csPropertyName = "onWheel"
-    , csFunc = \raw -> f (parseEvent raw) (parseMouseEvent raw) (parseWheelEvent raw)
+    , csFunc = runEvent $ \raw -> f (parseEvent raw) (parseMouseEvent raw) (parseWheelEvent raw)
     }
 
 --------------------------------------------------------------------------------
 --- Image
 --------------------------------------------------------------------------------
 
-onLoad :: (Event -> handler) -> PropertyOrHandler handler
+onLoad :: (Event -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onLoad = on "onLoad"
 
-onError :: (Event -> handler) -> PropertyOrHandler handler
+onError :: (Event -> EventHandlerTypeWithMods handler) -> PropertyOrHandler handler
 onError = on "onError"
 
 --------------------------------------------------------------------------------
@@ -626,6 +642,21 @@ foreign import javascript unsafe
     "$1['getModifierState']($2)"
     js_GetModifierState :: JSVal -> JSString -> JSVal
 
+-- | Call a handler *after* making sure the react event has been disconnected from the event pool.
+-- We assume that the return value of 'persistReactEvent' is turned into a synchronous callback
+-- (this usually happens in 'addPropOrHandlerToObj'); if the handler thread blocks, it is continued
+-- asynchronously.  That should be ok: the call to 'js_persistReactEvent' happens first and does not
+-- block, and after that the event is removed from the pool.
+--
+-- See https://facebook.github.io/react/docs/events.html,
+-- https://github.com/liqula/react-hs/issues/2 for more details.
+--
+-- ASSUMPTION: react always gives us the complete react event, with persist method and everything,
+-- if it is still in the pool.
+foreign import javascript unsafe
+  "if ($1 && $1['persist']) {$1.persist();} else {console.log('WARNING: PropertiesAndEvents.hs: <evt>.persist() failed on ', typeof($1), $1);}"
+  js_persistReactEvent :: HandlerArg -> IO ()
+
 #else
 
 js_preventDefault :: JSVal -> IO ()
@@ -645,5 +676,8 @@ js_getArrayProp _ _ = error "js_getArrayProp only works with GHCJS"
 
 js_GetModifierState :: JSVal -> JSString -> JSVal
 js_GetModifierState _ _ = error "js_GetModifierState only works with GHCJS"
+
+js_persistReactEvent :: HandlerArg -> IO ()
+js_persistReactEvent _ = error "js_persistReactEvent only works with GHCJS"
 
 #endif

--- a/react-hs/src/React/Flux/Views.hs
+++ b/react-hs/src/React/Flux/Views.hs
@@ -1,6 +1,5 @@
 -- | Internal module containing the view definitions
-{-# LANGUAGE UndecidableInstances, AllowAmbiguousTypes, CPP, TypeApplications, BangPatterns, ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 module React.Flux.Views
   ( View(..)
   , ViewPropsToElement
@@ -25,7 +24,6 @@ module React.Flux.Views
   ) where
 
 import Data.Typeable
-import Control.DeepSeq
 import qualified Data.HashMap.Strict as M
 
 import React.Flux.Store
@@ -47,7 +45,7 @@ import qualified JavaScript.Array as JSA
 
 newtype View (props :: [*]) = View (ReactViewRef ())
 
-type family ViewPropsToElement (props :: [*]) (handler :: *) where
+type family ViewPropsToElement (props :: [*]) (handler :: EventHandlerCode *) where
   ViewPropsToElement '[] handler = ReactElementM handler ()
   ViewPropsToElement (a ': rest) handler = a -> ViewPropsToElement rest handler
 
@@ -66,17 +64,20 @@ type ViewEventHandler = [SomeStoreAction]
 -- instead use the state passed directly to the handler.
 type StatefulViewEventHandler state = state -> ([SomeStoreAction], Maybe state)
 
+-- FIXME: make EventHandlerType closed
+type instance EventHandlerType 'EventHandlerCode = ViewEventHandler
+type instance EventHandlerType ('StatefulEventHandlerCode a) = StatefulViewEventHandler a
+
 -- | Change the event handler from 'ViewEventHandler' to 'StatefulViewEventHandler' to allow you to embed
 -- combinators with 'ViewEventHandler's into a stateful view.  Each such lifted handler makes no change to
 -- the state.
-liftViewToStateHandler :: ReactElementM ViewEventHandler a -> ReactElementM (StatefulViewEventHandler st) a
+liftViewToStateHandler :: ReactElementM 'EventHandlerCode a -> ReactElementM ('StatefulEventHandlerCode st) a
 liftViewToStateHandler = transHandler (\h _ -> (h, Nothing))
-
 
 class HasField (x :: k) r a | x r -> a where
   getField :: r -> a
 
-type family ControllerViewToElement (stores :: [*]) (props :: [*]) (handler :: *) where
+type family ControllerViewToElement (stores :: [*]) (props :: [*]) (handler :: EventHandlerCode *) where
   ControllerViewToElement '[] props handler = ViewPropsToElement props handler
   ControllerViewToElement (StoreArg store ': rest) props handler = store -> ControllerViewToElement rest props handler
   ControllerViewToElement (StoreField store field a ': rest) props handler = a -> ControllerViewToElement rest props handler
@@ -85,37 +86,39 @@ type family ControllerViewToElement (stores :: [*]) (props :: [*]) (handler :: *
 -- View Props Classes
 --------------------------------------------------------------------------------
 
-class ViewProps (props :: [*]) where
-  viewPropsToJs :: Proxy props -> Proxy handler -> ReactViewRef () -> JSString -> (NewJsProps -> IO ()) -> ViewPropsToElement props handler
-  applyViewPropsFromJs :: Proxy props -> ViewPropsToElement props handler -> NewJsProps -> Int -> IO (ReactElementM handler ())
+class ViewProps (props :: [*]) (handler :: EventHandlerCode *) where
+  viewPropsToJs :: ReactViewRef () -> JSString -> (NewJsProps -> IO ()) -> ViewPropsToElement props handler
+  applyViewPropsFromJs :: ViewPropsToElement props handler -> NewJsProps -> Int -> IO (ReactElementM handler ())
 
-class ExportViewProps (props :: [*]) where
-  applyViewPropsFromArray :: Proxy props -> JSArray -> Int -> NewJsProps -> IO ()
+class ExportViewProps (props :: [*]) handler where
+  applyViewPropsFromArray :: JSArray -> Int -> NewJsProps -> IO ()
 
-instance ViewProps '[] where
-  viewPropsToJs _ _ ref k props = elementToM () $ NewViewElement ref k props
-  applyViewPropsFromJs _ x _ _ = return x
+instance ViewProps '[] handler where
+  viewPropsToJs ref k props = elementToM () $ NewViewElement ref k props
+  applyViewPropsFromJs x _ _ = return x
   {-# INLINE viewPropsToJs #-}
   {-# INLINE applyViewPropsFromJs #-}
 
-instance ExportViewProps '[] where
-  applyViewPropsFromArray _ _ _ _ = return ()
+instance ExportViewProps '[] handler where
+  applyViewPropsFromArray _ _ _ = return ()
 
-instance (ViewProps rest, Typeable a) => ViewProps (a ': (rest :: [*])) where
-  viewPropsToJs _ h ref k props = \a -> viewPropsToJs (Proxy :: Proxy rest) h ref k (\p -> props p >> pushProp a p)
+instance (ViewProps rest handler, Typeable a)
+      => ViewProps (a ': (rest :: [*])) handler where
+  viewPropsToJs ref k props = \a -> viewPropsToJs @rest @handler ref k (\p -> props p >> pushProp a p)
   {-# INLINE viewPropsToJs #-}
 
-  applyViewPropsFromJs _ f props i = do
+  applyViewPropsFromJs f props i = do
     val <- getProp props i
-    applyViewPropsFromJs (Proxy :: Proxy rest) (f val) props (i+1)
+    applyViewPropsFromJs @rest (f val) props (i+1)
   {-# INLINE applyViewPropsFromJs #-}
 
-instance forall (rest :: [*]) a. (ExportViewProps rest, Typeable a, FromJSVal a) => ExportViewProps (a ': rest) where
-  applyViewPropsFromArray _ inputArr k outputArr =
+instance forall handler (rest :: [*]) a. (ExportViewProps rest handler, Typeable a, FromJSVal a)
+      => ExportViewProps (a ': rest) handler where
+  applyViewPropsFromArray inputArr k outputArr =
     do ma <- fromJSVal $ if k >= JSA.length inputArr then nullRef else JSA.index k inputArr
        a :: a <- maybe (error "Unable to decode callback argument") return ma
        pushProp a outputArr
-       applyViewPropsFromArray (Proxy :: Proxy rest) inputArr (k+1) outputArr
+       applyViewPropsFromArray @rest @handler inputArr (k+1) outputArr
 
 --------------------------------------------------------------------------------
 -- Controller View Props Classes
@@ -129,43 +132,43 @@ data StoreToState = StoreState Int
                     , storeToStateCallback :: IO (Callback (JSVal -> IO ()))
                     }
 
-class ControllerViewStores (stores :: [*]) where
-  applyControllerViewFromJs :: forall props handler. ViewProps props
-                            => Proxy stores
-                            -> Proxy props
-                            -> ControllerViewToElement stores props handler
+class ControllerViewStores (stores :: [*]) props (handler :: EventHandlerCode *) where
+  applyControllerViewFromJs :: ViewProps props handler
+                            => ControllerViewToElement stores props handler
                             -> JsState
                             -> NewJsProps
                             -> Int
                             -> IO (ReactElementM handler ())
-  stateForView :: Proxy stores -> Int -> M.HashMap TypeRep [StoreToState]
+  stateForView :: Int -> M.HashMap TypeRep [StoreToState]
 
 
-instance ControllerViewStores '[] where
-  applyControllerViewFromJs _ p f _ props _ = applyViewPropsFromJs p f props 0
-  stateForView _ _ = mempty
+instance ControllerViewStores '[] props handler where
+  applyControllerViewFromJs f _ props _ = applyViewPropsFromJs @props @handler f props 0
+  stateForView _ = mempty
   {-# INLINE applyControllerViewFromJs #-}
   {-# INLINE stateForView #-}
 
-instance (ControllerViewStores rest, StoreData store, Typeable store)
-   => ControllerViewStores (StoreArg store ': (rest :: [*])) where
-  applyControllerViewFromJs _ p f st props i = do
+instance (ControllerViewStores rest props handler, StoreData store, Typeable store)
+   => ControllerViewStores (StoreArg store ': (rest :: [*])) props handler where
+  applyControllerViewFromJs f st props i = do
     sval <- findFromState i st
-    applyControllerViewFromJs (Proxy :: Proxy rest) p (f sval) st props (i+1)
+    applyControllerViewFromJs @rest @props @handler (f sval) st props (i+1)
 
-  stateForView _ i = M.insertWith (++) storeT [StoreState i] (stateForView (Proxy :: Proxy rest) (i+1))
+  stateForView i = M.insertWith (++) storeT [StoreState i] (stateForView @rest @props @handler (i+1))
     where
       storeT = typeRep (Proxy :: Proxy store)
   {-# INLINE applyControllerViewFromJs #-}
   {-# INLINE stateForView #-}
 
-instance (ControllerViewStores rest, StoreData store, HasField field store a, Typeable store, Typeable a)
-   => ControllerViewStores (StoreField store field a ': (rest :: [*])) where
-  applyControllerViewFromJs _ p f st props i = do
+instance ( ControllerViewStores rest props handler
+         , StoreData store, HasField field store a, Typeable store, Typeable a
+         )
+   => ControllerViewStores (StoreField store field a ': (rest :: [*])) props handler where
+  applyControllerViewFromJs f st props i = do
     sval <- findFromState i st
-    applyControllerViewFromJs (Proxy :: Proxy rest) p (f sval) st props (i+1)
+    applyControllerViewFromJs @rest @props @handler (f sval) st props (i+1)
 
-  stateForView _ i = M.insertWith (++) storeT [StoreDerivedState i derive] (stateForView (Proxy :: Proxy rest) (i+1))
+  stateForView i = M.insertWith (++) storeT [StoreDerivedState i derive] (stateForView @rest @props @handler (i+1))
     where
       storeT = typeRep (Proxy :: Proxy store)
       derive =
@@ -186,17 +189,18 @@ getStoreJs arg = js_getDeriveInput arg >>= unsafeDerefExport "getStoreJs"
 -- Public API Implementation
 ---------------------------------------------------------------------------------
 
-view_ :: forall props handler. ViewProps (props :: [*]) => View props -> JSString -> ViewPropsToElement props handler
-view_ (View ref) key = viewPropsToJs (Proxy :: Proxy props) (Proxy :: Proxy handler) ref key (const $ return ())
+view_ :: forall props handler. ViewProps (props :: [*]) handler
+    => View props -> JSString -> ViewPropsToElement props handler
+view_ (View ref) key = viewPropsToJs @props @handler ref key (const $ return ())
 
-mkView :: forall (props :: [*]). (ViewProps props, Typeable props, AllEq props)
-    => JSString -> ViewPropsToElement props ViewEventHandler -> View props
+mkView :: forall (props :: [*]). (ViewProps props 'EventHandlerCode, Typeable props, AllEq props)
+    => JSString -> ViewPropsToElement props 'EventHandlerCode -> View props
 mkView name buildNode = unsafePerformIO $ do
   renderCb <- syncCallback2 ContinueAsync $ \thisRef argRef -> do
     let this = ReactThis thisRef
         arg = RenderCbArg argRef
     props <- js_PropsList this
-    node <- applyViewPropsFromJs (Proxy :: Proxy props) buildNode props 0
+    node <- applyViewPropsFromJs @props @'EventHandlerCode buildNode props 0
     (element, evtCallbacks) <- mkReactElement (runViewHandler this) this node
     evtCallbacksRef <- toJSVal evtCallbacks
     js_RenderCbSetResults arg evtCallbacksRef element
@@ -206,11 +210,11 @@ mkView name buildNode = unsafePerformIO $ do
 {-# NOINLINE mkView #-}
 
 mkStatefulView :: forall (state :: *) (props :: [*]).
-                  (Typeable state, NFData state, Typeable state, Eq state,
-                   ViewProps props, Typeable props, AllEq props)
+                  (Typeable state, Typeable state, Eq state,
+                   ViewProps props ('StatefulEventHandlerCode state), Typeable props, AllEq props)
                => JSString -- ^ A name for this view, used only for debugging/console logging
                -> state -- ^ The initial state
-               -> (state -> ViewPropsToElement props (StatefulViewEventHandler state))
+               -> (state -> ViewPropsToElement props ('StatefulEventHandlerCode state))
                -> View props
 mkStatefulView name initial buildNode = unsafePerformIO $ do
   initialRef <- export initial
@@ -219,7 +223,7 @@ mkStatefulView name initial buildNode = unsafePerformIO $ do
         arg = RenderCbArg argRef
     props <- js_PropsList this
     state <- js_ReactGetState this >>= unsafeDerefExport "mkStatefulView"
-    node <- applyViewPropsFromJs (Proxy :: Proxy props) (buildNode state) props 0
+    node <- applyViewPropsFromJs @props (buildNode state) props 0
     (element, evtCallbacks) <- mkReactElement (runStateViewHandler this) this node
     evtCallbacksRef <- toJSVal evtCallbacks
     js_RenderCbSetResults arg evtCallbacksRef element
@@ -230,16 +234,16 @@ mkStatefulView name initial buildNode = unsafePerformIO $ do
 {-# NOINLINE mkStatefulView #-}
 
 mkControllerView :: forall (stores :: [*]) (props :: [*]).
-                    (ControllerViewStores stores, Typeable stores, AllEq stores,
-                     ViewProps props, Typeable props, AllEq props)
-                 => JSString -> ControllerViewToElement stores props ViewEventHandler -> View props
+                    (ControllerViewStores stores props 'EventHandlerCode, Typeable stores, AllEq stores,
+                     ViewProps props 'EventHandlerCode, Typeable props, AllEq props)
+                 => JSString -> ControllerViewToElement stores props 'EventHandlerCode -> View props
 mkControllerView name buildNode = unsafePerformIO $ do
   renderCb <- syncCallback2 ContinueAsync $ \thisRef argRef -> do
     let this = ReactThis thisRef
         arg = RenderCbArg argRef
     props <- js_PropsList this
     st <- js_NewStateDict this
-    node <- applyControllerViewFromJs (Proxy :: Proxy stores) (Proxy :: Proxy props) buildNode st props 0
+    node <- applyControllerViewFromJs @stores @props buildNode st props 0
     (element, evtCallbacks) <- mkReactElement (runViewHandler this) this node
     evtCallbacksRef <- toJSVal evtCallbacks
     js_RenderCbSetResults arg evtCallbacksRef element
@@ -255,7 +259,7 @@ mkControllerView name buildNode = unsafePerformIO $ do
   -- ToJSVal instance.
 
   artifacts <- js_emptyArtifacts
-  forM_ (M.toList $ stateForView (Proxy :: Proxy stores) 0) $ \(ty, states) -> do
+  forM_ (M.toList $ stateForView @stores @props @'EventHandlerCode 0) $ \(ty, states) -> do
     art <- js_newArtifact
     forM_ states $ \s -> do
       case s of
@@ -268,18 +272,21 @@ mkControllerView name buildNode = unsafePerformIO $ do
   View <$> js_createNewCtrlView name renderCb artifacts propsEq stateEq
 {-# NOINLINE mkControllerView #-}
 
-exportReactViewToJavaScript :: forall (props :: [*]). (ExportViewProps props) => View props -> IO JSVal
+exportReactViewToJavaScript :: forall (props :: [*]) handler. (ExportViewProps props handler)
+    => View props -> IO JSVal
 exportReactViewToJavaScript (View v) = do
-  (_callbackToRelease, wrappedCb) <- exportNewViewToJs v (getProps @props Proxy)
+  (_callbackToRelease, wrappedCb) <- exportNewViewToJs v (getProps @props @handler)
   return wrappedCb
 
-callbackRenderingView :: forall (props :: [*]) handler. (ExportViewProps props) => JSString -> View props -> PropertyOrHandler handler
-callbackRenderingView name (View v) = CallbackPropertyReturningNewView name v (getProps @props Proxy)
+callbackRenderingView :: forall (props :: [*]) handler. (ExportViewProps props handler)
+    => JSString -> View props -> PropertyOrHandler handler
+callbackRenderingView name (View v) = CallbackPropertyReturningNewView name v (getProps @props @handler)
 
-getProps :: forall (props :: [*]). (ExportViewProps props) => Proxy props -> JSArray -> IO NewJsProps
-getProps proxy arr = do
+getProps :: forall (props :: [*]) handler. (ExportViewProps props handler)
+    => JSArray -> IO NewJsProps
+getProps arr = do
   props <- js_newEmptyPropList
-  applyViewPropsFromArray proxy arr 0 props
+  applyViewPropsFromArray @props @handler arr 0 props
   return props
 
 
@@ -287,13 +294,12 @@ getProps proxy arr = do
 -- Helpers
 --------------------------------------------------------------------------------
 
--- | Transform a controller view handler to a raw handler.  Runs 'deepseq' on the actions so event
--- handler (if contained in there) is still valid.  See haddocks of 'preventDefault'.
+-- | Transform a controller view handler to a raw handler.
 runViewHandler :: ReactThis state props -> ViewEventHandler -> IO ()
-runViewHandler _ handler = handler `deepseq` mapM_ executeAction handler
+runViewHandler _ = mapM_ executeAction
 
 -- | Transform a stateful view event handler to a raw event handler.
-runStateViewHandler :: (Typeable state, NFData state)
+runStateViewHandler :: (Typeable state)
                     => ReactThis state props -> StatefulViewEventHandler state -> IO ()
 runStateViewHandler this handler = do
   st <- js_ReactGetState this >>= unsafeDerefExport "runStateViewHandler"
@@ -303,14 +309,10 @@ runStateViewHandler this handler = do
   case mNewState of
     Nothing -> return ()
     Just newState -> do
-      newStateRef <- newState `deepseq` export newState
+      newStateRef <- export newState
       js_ReactUpdateAndReleaseState this newStateRef
 
-  -- nothing above here should block, so the handler callback should still be running syncronous,
-  -- so the deepseq of actions should still pick up the proper event object.
-  --
-  -- TODO: I'm not so optimistic about the above code not blocking (is that the same as yielding?)
-  actions `deepseq` mapM_ executeAction actions
+  executeAction `mapM_` actions
 
 getProp :: Typeable a => NewJsProps -> Int -> IO a
 getProp p i = js_getPropFromList p i >>= unsafeDerefExport "getProp"

--- a/react-hs/test/client/react-hs-test-client.cabal
+++ b/react-hs/test/client/react-hs-test-client.cabal
@@ -32,5 +32,31 @@ executable test-client
                 , react-hs
                 , time
                 , text
-                , deepseq
                 , aeson
+
+  default-extensions:
+    BangPatterns
+    CPP
+    DataKinds
+    DeriveGeneric
+    EmptyDataDecls
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    MagicHash
+    MultiParamTypeClasses
+    OverloadedStrings
+    PolyKinds
+    QuasiQuotes
+    RecordWildCards
+    ScopedTypeVariables
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns

--- a/react-hs/test/client/react-hs-test-client.cabal
+++ b/react-hs/test/client/react-hs-test-client.cabal
@@ -1,5 +1,5 @@
 name:                react-hs-test-client
-version:             0.0.1
+version:             0.1.0
 synopsis:            A test client for react-hs.
 category:            Web
 homepage:            https://github.com/liqula/react-hs

--- a/react-hs/test/spec/TestClientSpec.hs
+++ b/react-hs/test/spec/TestClientSpec.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -w #-}  -- FIXME: remove this line once the tests are working again.
 module TestClientSpec (spec) where
 

--- a/react-hs/test/spec/react-hs-spec.cabal
+++ b/react-hs/test/spec/react-hs-spec.cabal
@@ -1,5 +1,5 @@
 name: react-hs-spec
-version: 0.0.1
+version: 0.1.0
 build-type: Simple
 cabal-version: >= 1.9
 

--- a/react-hs/test/spec/react-hs-spec.cabal
+++ b/react-hs/test/spec/react-hs-spec.cabal
@@ -4,16 +4,43 @@ build-type: Simple
 cabal-version: >= 1.9
 
 executable react-hs-spec
-   ghc-options: -Wall
-   hs-source-dirs: .
-   main-is: Main.hs
-   other-modules: TestClientSpec, Spec
-   build-depends: base
-                , hspec
-                , webdriver
-                , hspec-webdriver >= 1.2
-                , directory
-                , process
-                , transformers
-                , text
-                , time
+  ghc-options: -Wall
+  hs-source-dirs: .
+  main-is: Main.hs
+  other-modules: TestClientSpec, Spec
+  build-depends: base
+               , hspec
+               , webdriver
+               , hspec-webdriver >= 1.2
+               , directory
+               , process
+               , transformers
+               , text
+               , time
+
+  default-extensions:
+    BangPatterns
+    CPP
+    DataKinds
+    DeriveGeneric
+    EmptyDataDecls
+    ExistentialQuantification
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GeneralizedNewtypeDeriving
+    LambdaCase
+    MagicHash
+    MultiParamTypeClasses
+    OverloadedStrings
+    PolyKinds
+    QuasiQuotes
+    RecordWildCards
+    ScopedTypeVariables
+    TemplateHaskell
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    UndecidableInstances
+    ViewPatterns

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,6 +22,7 @@ for target in $TARGETS; do
   cd $PROJECT_ROOT/$target
   test -e Makefile && make npm
   stack setup --allow-different-user
+  stack clean --allow-different-user
   stack build --allow-different-user --fast --pedantic --test
   test -e Makefile && make default
 done


### PR DESCRIPTION
Fixes #2.  Fixes #3.  Fixes #34.  Fixes #26.  Related: #15, #8.

- [x] Better implementation for `stopPropagation`, `preventDefault`.
- [x] Make `eventHandler` type kinded (more type safety).
- [x] Call `<evt>.persist()` implicitly on all react events to allow for threaded event handlers.
- [x] Remove `NFData` constraints from action, props, state types.
- [x] Remove some dead code from `Outdated`.

(Haddocks will be updated in a separate PR.)

(un-squashed backup of this branch: 2-concurrency-and-events-2)
