### PR TITLE
lambda example: add leftmost reduction strategy, fix normal reduction

### DIFF
--- a/react-hs-examples/lambda/src/LambdaAST.hs
+++ b/react-hs-examples/lambda/src/LambdaAST.hs
@@ -7,6 +7,7 @@ module LambdaAST
   , unAnno
   , ExprPath
   , collectPaths
+  , collectPathsNormal
   -- , applyAt
   , ppExpr
   ) where
@@ -66,6 +67,16 @@ collectPaths path expr =
     App _ fun@Abs{} arg ->
       path : collectPaths (False : path) fun ++ collectPaths (True : path) arg
     App _ fun arg -> collectPaths (False : path) fun ++ collectPaths (True : path) arg
+
+
+collectPathsNormal :: ExprPath -> Expr a -> [ExprPath]
+collectPathsNormal path expr =
+  case expr of
+    Var _ _ -> []
+    Abs _ _ _ -> []
+    App _ fun@Abs{} arg ->
+      path : collectPathsNormal (False : path) fun ++ collectPathsNormal (True : path) arg
+    App _ fun arg -> collectPathsNormal (False : path) fun ++ collectPathsNormal (True : path) arg
 
 
 --applyAt :: Monad m => ExprPath -> (Expr ann -> m (Expr ann)) -> Expr ann -> m (Expr ann)

--- a/react-hs-examples/lambda/src/LambdaEval.hs
+++ b/react-hs-examples/lambda/src/LambdaEval.hs
@@ -6,6 +6,7 @@ module LambdaEval
   , freshForConflicting
   , reduceOrConvert
   , runNextNormal
+  , runNextLeftmost
   , runNextRandom
   , runAll
   , randomItem
@@ -90,13 +91,27 @@ reduceOrConvert expr =
 runNextNormal :: Int -> Expr FBAnn -> Int -> (Expr FBAnn, Int, Bool)
 runNextNormal 0 expr counter = (expr, counter, True)
 runNextNormal n expr counter =
-  case collectPaths [] expr of
+  case collectPathsNormal [] expr of
     path : _ ->
       let
         (expr', counter') =
           runState (applyAtAndAnno (reverse path) reduceOrConvert expr) counter
       in
         runNextNormal (n-1) expr' counter'
+    _ ->
+      (expr, counter, False)
+
+
+runNextLeftmost :: Int -> Expr FBAnn -> Int -> (Expr FBAnn, Int, Bool)
+runNextLeftmost 0 expr counter = (expr, counter, True)
+runNextLeftmost n expr counter =
+  case collectPaths [] expr of
+    path : _ ->
+      let
+        (expr', counter') =
+          runState (applyAtAndAnno (reverse path) reduceOrConvert expr) counter
+      in
+        runNextLeftmost (n-1) expr' counter'
     _ ->
       (expr, counter, False)
 

--- a/react-hs-examples/lambda/src/LambdaStore.hs
+++ b/react-hs-examples/lambda/src/LambdaStore.hs
@@ -50,6 +50,7 @@ data LambdaAction
   = LambdaStepAt ExprPath
   | LambdaStepsNormal Int
   | LambdaStepsRandom Int
+  | LambdaStepsLeftmost Int
   | LambdaReset
   | LambdaSetText String
   | LambdaTick
@@ -111,6 +112,21 @@ runLambdaAction a oldState =
           let
             (expr', freshCounter', moreToDo) =
               runNextNormal n expr (freshCounter oldState)
+          in
+            return oldState { lambdaExpr = Just expr'
+                            , freshCounter = freshCounter'
+                            , reductionCount = reductionCount oldState + n
+                            , runTicks = (runTicks oldState && moreToDo)
+                            }
+        Nothing ->
+          return oldState
+
+    LambdaStepsLeftmost n ->
+      case lambdaExpr oldState of
+        Just expr ->
+          let
+            (expr', freshCounter', moreToDo) =
+              runNextLeftmost n expr (freshCounter oldState)
           in
             return oldState { lambdaExpr = Just expr'
                             , freshCounter = freshCounter'

--- a/react-hs-examples/lambda/src/LambdaViews.hs
+++ b/react-hs-examples/lambda/src/LambdaViews.hs
@@ -43,6 +43,7 @@ lambdaView ls = section_ ["id" $= "lambda"] $ do
       button_ [ "key" &= ("b7" :: String), onClick $ \_ _ -> handleLambda (LambdaStepsNormal 500) ] $ elemString "500 normal reductions"
       button_ [ "key" &= ("b8" :: String), onClick $ \_ _ -> handleLambda (LambdaStepsRandom 1) ] $ elemString "random reduction"
       button_ [ "key" &= ("b9" :: String), onClick $ \_ _ -> handleLambda (LambdaStepsRandom 50) ] $ elemString "50 random reductions"
+      button_ [ "key" &= ("b10" :: String), onClick $ \_ _ -> handleLambda (LambdaStepsLeftmost 1) ] $ elemString "leftmost reduction"
     div_ [ "key" &= ("d5" :: String)] $ elemString (show $ reductionCount ls)
     div_ [ "key" &= ("d6" :: String)] $ viewExpr (lambdaExpr ls)
 


### PR DESCRIPTION
normal reduction evaluated the leftmost application of a lambda even if it was inside another lambda. corrected now.