### PR TITLE
Remove class with only one instance

### DIFF
--- a/react-hs/src/React/Flux.hs
+++ b/react-hs/src/React/Flux.hs
@@ -102,7 +102,6 @@ module React.Flux (
   , ViewEventHandler
   , View
   , ViewPropsToElement
-  , ViewProps
   , mkView
   , StatefulViewEventHandler
   , mkStatefulView


### PR DESCRIPTION
The ViewProps and ExportViewProps typeclasses now only have one instance (after the move to single props).

This clean up removes some unnecessary indirection